### PR TITLE
allow minor and patch Faraday versions

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.12']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 1.0']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
from faraday maintainer
``
I already try not to have feature changes between patch releases, only
bugfixes. That was the philosophy between all past 0.8.x releases.
When we're ready to release 1.0, then we'll know it is stable. Until
then, the patch releases will signify bug fixes and minor releases will
signify API upgrades, just like semver.
``
https://github.com/lostisland/faraday/issues/515#issuecomment-146046693

this versioning strategy is the same that is used in the
faraday_middleware gem
https://github.com/lostisland/faraday_middleware/blob/master/faraday_middleware.gemspec#L16